### PR TITLE
[Phase 4] Contextual & Prompt Generation modules

### DIFF
--- a/app/extensions/context_providers/__init__.py
+++ b/app/extensions/context_providers/__init__.py
@@ -1,6 +1,8 @@
 from .dummy_context_provider import DummyContextProvider
+from .symbol_graph_provider import SymbolGraphProvider
 from ...registries.context_providers import CONTEXT_PROVIDER_REGISTRY
 
 CONTEXT_PROVIDER_REGISTRY.register("dummy", DummyContextProvider)
+CONTEXT_PROVIDER_REGISTRY.register("symbol_graph", SymbolGraphProvider)
 
-__all__ = ["DummyContextProvider"]
+__all__ = ["DummyContextProvider", "SymbolGraphProvider"]

--- a/app/extensions/context_providers/symbol_graph_provider.py
+++ b/app/extensions/context_providers/symbol_graph_provider.py
@@ -1,0 +1,71 @@
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+from typing import Any, Dict, List, Set
+
+from ...abstract_classes.context_provider_base import ContextProviderBase
+
+
+class SymbolGraphProvider(ContextProviderBase):
+    """Generate a simple symbol graph for a Python module."""
+
+    def __init__(self, module_path: str) -> None:
+        super().__init__()
+        self.module_path = Path(module_path)
+
+    def _get_context(self) -> Dict[str, Any]:
+        """Parse the module and return context information."""
+        if not self.module_path.exists():
+            self.logger.error("Module not found: %s", self.module_path)
+            return {}
+
+        source = self.module_path.read_text(encoding="utf-8")
+        tree = ast.parse(source)
+
+        functions: List[str] = []
+        classes: Dict[str, List[str]] = {}
+        call_map: Dict[str, Set[str]] = {}
+
+        for node in tree.body:
+            if isinstance(node, ast.FunctionDef):
+                sig = self._format_signature(node)
+                functions.append(sig)
+                call_map[node.name] = self._collect_calls(node)
+            elif isinstance(node, ast.ClassDef):
+                method_sigs: List[str] = []
+                for item in node.body:
+                    if isinstance(item, ast.FunctionDef):
+                        sig = self._format_signature(item)
+                        method_sigs.append(sig)
+                        key = f"{node.name}.{item.name}"
+                        call_map[key] = self._collect_calls(item)
+                classes[node.name] = method_sigs
+
+        context = {
+            "functions": functions,
+            "classes": classes,
+            "call_map": {k: sorted(v) for k, v in call_map.items()},
+        }
+        self.logger.info("Context generated for %s", self.module_path)
+        return context
+
+    def _format_signature(self, func: ast.FunctionDef) -> str:
+        args = [arg.arg for arg in func.args.args]
+        if func.args.vararg:
+            args.append("*" + func.args.vararg.arg)
+        for kw in func.args.kwonlyargs:
+            args.append(kw.arg)
+        if func.args.kwarg:
+            args.append("**" + func.args.kwarg.arg)
+        return f"{func.name}({', '.join(args)})"
+
+    def _collect_calls(self, func: ast.FunctionDef) -> Set[str]:
+        calls: Set[str] = set()
+        for node in ast.walk(func):
+            if isinstance(node, ast.Call):
+                if isinstance(node.func, ast.Name):
+                    calls.add(node.func.id)
+                elif isinstance(node.func, ast.Attribute):
+                    calls.add(node.func.attr)
+        return calls

--- a/app/extensions/prompt_generators/__init__.py
+++ b/app/extensions/prompt_generators/__init__.py
@@ -1,6 +1,8 @@
 from .dummy_prompt_generator import DummyPromptGenerator
+from .basic_prompt_generator import BasicPromptGenerator
 from ...registries.prompt_generators import PROMPT_GENERATOR_REGISTRY
 
 PROMPT_GENERATOR_REGISTRY.register("dummy", DummyPromptGenerator)
+PROMPT_GENERATOR_REGISTRY.register("basic", BasicPromptGenerator)
 
-__all__ = ["DummyPromptGenerator"]
+__all__ = ["DummyPromptGenerator", "BasicPromptGenerator"]

--- a/app/extensions/prompt_generators/basic_prompt_generator.py
+++ b/app/extensions/prompt_generators/basic_prompt_generator.py
@@ -1,0 +1,34 @@
+from __future__ import annotations
+
+from typing import Any, Dict
+
+from ...abstract_classes.prompt_generator_base import PromptGeneratorBase
+from ...abstract_classes.context_provider_base import ContextProviderBase
+
+
+class BasicPromptGenerator(PromptGeneratorBase):
+    """Combine system and agent templates with code context."""
+
+    def __init__(self, context_provider: ContextProviderBase) -> None:
+        super().__init__()
+        self.context_provider = context_provider
+
+    def _generate_prompt(
+        self, agent_config: Dict[str, Any], system_config: Dict[str, Any]
+    ) -> str:
+        context = self.context_provider.get_context()
+        self.logger.debug("Raw context: %s", context)
+
+        system_template = system_config.get("template", "")
+        agent_template = agent_config.get("template", "")
+
+        context_snippet = ""
+        if context:
+            funcs = ", ".join(context.get("functions", []))
+            classes = ", ".join(context.get("classes", {}).keys())
+            context_snippet = f"Functions: {funcs}\nClasses: {classes}"
+
+        prompt = f"{system_template}\n\n{agent_template}\n\n{context_snippet}"
+        self.logger.info("Prompt generated")
+        self.logger.debug("Prompt content: %s", prompt)
+        return prompt

--- a/app/factories/context_provider.py
+++ b/app/factories/context_provider.py
@@ -1,0 +1,12 @@
+from __future__ import annotations
+
+from ..registries.context_providers import CONTEXT_PROVIDER_REGISTRY
+
+
+class ContextProviderFactory:
+    @staticmethod
+    def create(name: str, **kwargs):
+        cls = CONTEXT_PROVIDER_REGISTRY.get(name)
+        if cls is None:
+            raise KeyError(f"Context provider {name} not registered")
+        return cls(**kwargs)

--- a/phase2_validation.ipynb
+++ b/phase2_validation.ipynb
@@ -2,7 +2,7 @@
  "cells": [
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": 1,
    "id": "5bc4997c",
    "metadata": {},
    "outputs": [
@@ -10,12 +10,12 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "StateTransitionLog(experiment_id='exp', round=0, from_state='start', to_state='generate', reason=None, timestamp=datetime.datetime(2025, 5, 17, 21, 9, 39, 65951))\n",
-      "StateTransitionLog(experiment_id='exp', round=0, from_state='generate', to_state='discriminate', reason=None, timestamp=datetime.datetime(2025, 5, 17, 21, 9, 39, 65951))\n",
-      "StateTransitionLog(experiment_id='exp', round=0, from_state='discriminate', to_state='mediate', reason=None, timestamp=datetime.datetime(2025, 5, 17, 21, 9, 39, 65951))\n",
-      "StateTransitionLog(experiment_id='exp', round=0, from_state='mediate', to_state='patchor', reason=None, timestamp=datetime.datetime(2025, 5, 17, 21, 9, 39, 65951))\n",
-      "StateTransitionLog(experiment_id='exp', round=0, from_state='patchor', to_state='recommender', reason=None, timestamp=datetime.datetime(2025, 5, 17, 21, 9, 39, 65951))\n",
-      "StateTransitionLog(experiment_id='exp', round=0, from_state='recommender', to_state='end', reason=None, timestamp=datetime.datetime(2025, 5, 17, 21, 9, 39, 65951))\n"
+      "StateTransitionLog(experiment_id='exp', round=0, from_state='start', to_state='generate', reason=None, timestamp=datetime.datetime(2025, 5, 18, 0, 15, 11, 51497))\n",
+      "StateTransitionLog(experiment_id='exp', round=0, from_state='generate', to_state='discriminate', reason=None, timestamp=datetime.datetime(2025, 5, 18, 0, 15, 11, 51497))\n",
+      "StateTransitionLog(experiment_id='exp', round=0, from_state='discriminate', to_state='mediate', reason=None, timestamp=datetime.datetime(2025, 5, 18, 0, 15, 11, 51497))\n",
+      "StateTransitionLog(experiment_id='exp', round=0, from_state='mediate', to_state='patchor', reason=None, timestamp=datetime.datetime(2025, 5, 18, 0, 15, 11, 51497))\n",
+      "StateTransitionLog(experiment_id='exp', round=0, from_state='patchor', to_state='recommender', reason=None, timestamp=datetime.datetime(2025, 5, 18, 0, 15, 11, 51497))\n",
+      "StateTransitionLog(experiment_id='exp', round=0, from_state='recommender', to_state='end', reason=None, timestamp=datetime.datetime(2025, 5, 18, 0, 15, 11, 51497))\n"
      ]
     }
    ],

--- a/phase3_validation.ipynb
+++ b/phase3_validation.ipynb
@@ -32,7 +32,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": 3,
    "id": "e8902ae3",
    "metadata": {},
    "outputs": [
@@ -40,8 +40,8 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Generator Logs: [PromptLog(experiment_id='exp', round=0, system='system', agent_id='generator', agent_role='fixer', agent_engine=None, symbol='validation_sample.py', prompt='format code', response=None, attempt_number=0, agent_action_outcome='success', start=datetime.datetime(2025, 5, 17, 22, 30, 25, 67469), stop=datetime.datetime(2025, 5, 17, 22, 30, 25, 282092))]\n",
-      "Evaluator Logs: [CodeQualityLog(experiment_id='exp', round=0, symbol='validation_sample.py', lines_of_code=1, cyclomatic_complexity=0.0, maintainability_index=0.0, lint_errors=0, timestamp=datetime.datetime(2025, 5, 17, 22, 30, 26, 307540))]\n"
+      "Generator Logs: [PromptLog(experiment_id='exp', round=0, system='system', agent_id='generator', agent_role='fixer', agent_engine=None, symbol='validation_sample.py', prompt='format code', response=None, attempt_number=0, agent_action_outcome='success', start=datetime.datetime(2025, 5, 18, 0, 15, 6, 122603), stop=datetime.datetime(2025, 5, 18, 0, 15, 6, 313080))]\n",
+      "Evaluator Logs: [CodeQualityLog(experiment_id='exp', round=0, symbol='validation_sample.py', lines_of_code=1, cyclomatic_complexity=0.0, maintainability_index=0.0, lint_errors=0, timestamp=datetime.datetime(2025, 5, 18, 0, 15, 6, 688811))]\n"
      ]
     }
    ],

--- a/phase4_validation.ipynb
+++ b/phase4_validation.ipynb
@@ -1,0 +1,58 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "id": "phase4-demo",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from importlib import import_module\n",
+    "from pathlib import Path\n",
+    "\n",
+    "from app.factories.context_provider import ContextProviderFactory\n",
+    "from app.factories.prompt_manager import PromptGeneratorFactory\n",
+    "\n",
+    "import_module(\"app.extensions.context_providers\")\n",
+    "import_module(\"app.extensions.prompt_generators\")\n",
+    "\n",
+    "sample = Path('sample_module.py')\n",
+    "sample.write_text('''\n",
+    "def foo(x):\n",
+    "    return x + 1\n",
+    "\n",
+    "class Bar:\n",
+    "    def baz(self, y):\n",
+    "        return foo(y)\n",
+    "''')\n",
+    "\n",
+    "provider = ContextProviderFactory.create('symbol_graph', module_path=str(sample))\n",
+    "context = provider.get_context()\n",
+    "print(context)\n",
+    "\n",
+    "agent_cfg = {'template': 'Agent instructions'}\n",
+    "system_cfg = {'template': 'System instructions'}\n",
+    "generator = PromptGeneratorFactory.create('basic', context_provider=provider)\n",
+    "prompt = generator.generate_prompt(agent_cfg, system_cfg)\n",
+    "print(prompt)\n",
+    "\n",
+    "assert 'foo(' in prompt\n",
+    "assert 'Agent instructions' in prompt\n",
+    "assert 'System instructions' in prompt\n"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": ".venv",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python",
+   "version": "3.12.6"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/phase4_validation.ipynb
+++ b/phase4_validation.ipynb
@@ -5,7 +5,21 @@
    "execution_count": 1,
    "id": "phase4-demo",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "{'functions': ['foo(x)'], 'classes': {'Bar': ['baz(self, y)']}, 'call_map': {'foo': [], 'Bar.baz': ['foo']}}\n",
+      "System instructions\n",
+      "\n",
+      "Agent instructions\n",
+      "\n",
+      "Functions: foo(x)\n",
+      "Classes: Bar\n"
+     ]
+    }
+   ],
    "source": [
     "from importlib import import_module\n",
     "from pathlib import Path\n",
@@ -16,29 +30,31 @@
     "import_module(\"app.extensions.context_providers\")\n",
     "import_module(\"app.extensions.prompt_generators\")\n",
     "\n",
-    "sample = Path('sample_module.py')\n",
-    "sample.write_text('''\n",
+    "sample = Path(\"sample_module.py\")\n",
+    "sample.write_text(\n",
+    "    \"\"\"\n",
     "def foo(x):\n",
     "    return x + 1\n",
     "\n",
     "class Bar:\n",
     "    def baz(self, y):\n",
     "        return foo(y)\n",
-    "''')\n",
+    "\"\"\"\n",
+    ")\n",
     "\n",
-    "provider = ContextProviderFactory.create('symbol_graph', module_path=str(sample))\n",
+    "provider = ContextProviderFactory.create(\"symbol_graph\", module_path=str(sample))\n",
     "context = provider.get_context()\n",
     "print(context)\n",
     "\n",
-    "agent_cfg = {'template': 'Agent instructions'}\n",
-    "system_cfg = {'template': 'System instructions'}\n",
-    "generator = PromptGeneratorFactory.create('basic', context_provider=provider)\n",
+    "agent_cfg = {\"template\": \"Agent instructions\"}\n",
+    "system_cfg = {\"template\": \"System instructions\"}\n",
+    "generator = PromptGeneratorFactory.create(\"basic\", context_provider=provider)\n",
     "prompt = generator.generate_prompt(agent_cfg, system_cfg)\n",
     "print(prompt)\n",
     "\n",
-    "assert 'foo(' in prompt\n",
-    "assert 'Agent instructions' in prompt\n",
-    "assert 'System instructions' in prompt\n"
+    "assert \"foo(\" in prompt\n",
+    "assert \"Agent instructions\" in prompt\n",
+    "assert \"System instructions\" in prompt"
    ]
   }
  ],
@@ -49,7 +65,15 @@
    "name": "python3"
   },
   "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
    "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
    "version": "3.12.6"
   }
  },

--- a/sample_module.py
+++ b/sample_module.py
@@ -1,0 +1,7 @@
+def foo(x):
+    return x + 1
+
+
+class Bar:
+    def baz(self, y):
+        return foo(y)

--- a/tests/test_factories.py
+++ b/tests/test_factories.py
@@ -6,6 +6,7 @@ from app.factories.state_manager import StateManagerFactory
 from app.factories.prompt_manager import PromptGeneratorFactory
 from app.factories.tool_provider import ToolProviderFactory
 from app.factories.scoring_provider import ScoringProviderFactory
+from app.factories.context_provider import ContextProviderFactory
 
 
 def _load_extensions():
@@ -46,10 +47,17 @@ def test_state_manager_factory():
     assert manager is not None
 
 
+def test_context_provider_factory():
+    _ensure_loaded()
+    provider = ContextProviderFactory.create("dummy")
+    assert provider.get_context() == {}
+
+
 def test_prompt_generator_factory():
     _ensure_loaded()
-    generator = PromptGeneratorFactory.create("dummy")
-    assert generator.generate_prompt() == "dummy prompt"
+    provider = ContextProviderFactory.create("dummy")
+    generator = PromptGeneratorFactory.create("basic", context_provider=provider)
+    assert isinstance(generator.generate_prompt({}, {}), str)
 
 
 def test_tool_provider_factory():


### PR DESCRIPTION
## Summary
- implement `SymbolGraphProvider` for AST-based context
- implement `BasicPromptGenerator` that merges templates and context
- register new extensions
- add factory for context providers
- include validation notebook for Phase 4
- extend factory tests

## Testing
- `black .`
- `mypy .`
- `ruff check .` *(fails: 6 errors)*
- `python -m pytest -q` *(fails: No module named pytest)*