### PR TITLE
[Phase 7] Schema layer and seed loader

### DIFF
--- a/app/schemas/__init__.py
+++ b/app/schemas/__init__.py
@@ -1,0 +1,29 @@
+from .agent_engine_schema import AgentEngine
+from .agent_prompt_schema import AgentPrompt
+from .system_prompt_schema import SystemPrompt
+from .context_provider_schema import ContextProvider
+from .tooling_provider_schema import ToolingProvider
+from .file_path_schema import FilePath
+from .agent_config_schema import AgentConfig
+from .prompt_generator_schema import PromptGenerator
+from .scoring_provider_schema import ScoringProvider
+from .state_manager_schema import StateManager
+from .system_config_schema import SystemConfig
+from .experiment_config_schema import ExperimentConfig
+from .series_schema import Series
+
+__all__ = [
+    "AgentEngine",
+    "AgentPrompt",
+    "SystemPrompt",
+    "ContextProvider",
+    "ToolingProvider",
+    "FilePath",
+    "AgentConfig",
+    "PromptGenerator",
+    "ScoringProvider",
+    "StateManager",
+    "SystemConfig",
+    "ExperimentConfig",
+    "Series",
+]

--- a/app/schemas/agent_config_schema.py
+++ b/app/schemas/agent_config_schema.py
@@ -1,0 +1,56 @@
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Optional, Union
+
+from pydantic import BaseModel, validator
+
+from .agent_engine_schema import AgentEngine
+from .prompt_generator_schema import PromptGenerator
+
+
+class AgentConfig(BaseModel):
+    """Schema for the agent_config table."""
+
+    id: Optional[int] = None
+    name: str
+    description: Optional[str] = None
+    agent_role: Optional[str] = None
+    system_type: Optional[str] = None
+    agent_engine_id: Optional[int] = None
+    prompt_generator_id: Optional[int] = None
+    agent_engine: Optional[AgentEngine] = None
+    prompt_generator: Optional[PromptGenerator] = None
+    artifact_path: Optional[Path] = None
+
+    table_name: str = "agent_config"
+
+    @validator("agent_engine", always=True)
+    def _sync_agent_engine_id(cls, v, values):
+        if v is not None and values.get("agent_engine_id") is None:
+            values["agent_engine_id"] = getattr(v, "id", None)
+        return v
+
+    @validator("prompt_generator", always=True)
+    def _sync_prompt_gen_id(cls, v, values):
+        if v is not None and values.get("prompt_generator_id") is None:
+            values["prompt_generator_id"] = getattr(v, "id", None)
+        return v
+
+    @validator("artifact_path")
+    def _check_path(cls, v: Optional[Path]) -> Optional[Path]:
+        if v is None:
+            return v
+        p = Path(v)
+        if not p.is_absolute() and ".." in p.parts:
+            raise ValueError("artifact_path must be absolute or project relative")
+        return p
+
+    def model_dump(self) -> dict:  # pragma: no cover - simple wrapper
+        data = self.dict()
+        for field in ("agent_engine", "prompt_generator"):
+            if data.get(field) is not None:
+                data[field] = data[field].model_dump()
+        if data.get("artifact_path") is not None:
+            data["artifact_path"] = str(data["artifact_path"])
+        return data

--- a/app/schemas/agent_engine_schema.py
+++ b/app/schemas/agent_engine_schema.py
@@ -1,0 +1,34 @@
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Optional
+
+from pydantic import BaseModel, validator
+
+
+class AgentEngine(BaseModel):
+    """Schema for the agent_engine table."""
+
+    id: Optional[int] = None
+    name: str
+    description: Optional[str] = None
+    model: Optional[str] = None
+    engine_config: Optional[str] = None
+    artifact_path: Optional[Path] = None
+
+    table_name: str = "agent_engine"
+
+    @validator("artifact_path")
+    def _check_path(cls, v: Optional[Path]) -> Optional[Path]:
+        if v is None:
+            return v
+        p = Path(v)
+        if not p.is_absolute() and ".." in p.parts:
+            raise ValueError("artifact_path must be absolute or project relative")
+        return p
+
+    def model_dump(self) -> dict:  # pragma: no cover - simple wrapper
+        data = self.dict()
+        if data.get("artifact_path") is not None:
+            data["artifact_path"] = str(data["artifact_path"])
+        return data

--- a/app/schemas/agent_prompt_schema.py
+++ b/app/schemas/agent_prompt_schema.py
@@ -1,0 +1,34 @@
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Optional
+
+from pydantic import BaseModel, validator
+
+
+class AgentPrompt(BaseModel):
+    """Schema for the agent_prompt table."""
+
+    id: Optional[int] = None
+    name: str
+    description: Optional[str] = None
+    agent_role: Optional[str] = None
+    system_type: Optional[str] = None
+    artifact_path: Optional[Path] = None
+
+    table_name: str = "agent_prompt"
+
+    @validator("artifact_path")
+    def _check_path(cls, v: Optional[Path]) -> Optional[Path]:
+        if v is None:
+            return v
+        p = Path(v)
+        if not p.is_absolute() and ".." in p.parts:
+            raise ValueError("artifact_path must be absolute or project relative")
+        return p
+
+    def model_dump(self) -> dict:  # pragma: no cover - simple wrapper
+        data = self.dict()
+        if data.get("artifact_path") is not None:
+            data["artifact_path"] = str(data["artifact_path"])
+        return data

--- a/app/schemas/context_provider_schema.py
+++ b/app/schemas/context_provider_schema.py
@@ -1,0 +1,32 @@
+from __future__ import annotations
+
+from typing import Optional
+
+from pydantic import BaseModel, validator
+
+from .tooling_provider_schema import ToolingProvider
+
+
+class ContextProvider(BaseModel):
+    """Schema for the context_provider table."""
+
+    id: Optional[int] = None
+    name: str
+    description: Optional[str] = None
+    system_type: Optional[str] = None
+    tooling_provider_id: Optional[int] = None
+    tooling_provider: Optional[ToolingProvider] = None
+
+    table_name: str = "context_provider"
+
+    @validator("tooling_provider", always=True)
+    def _check_fk(cls, v, values):
+        if v is not None and values.get("tooling_provider_id") is None:
+            values["tooling_provider_id"] = getattr(v, "id", None)
+        return v
+
+    def model_dump(self) -> dict:  # pragma: no cover - simple wrapper
+        data = self.dict()
+        if data.get("tooling_provider") is not None:
+            data["tooling_provider"] = data["tooling_provider"].model_dump()
+        return data

--- a/app/schemas/experiment_config_schema.py
+++ b/app/schemas/experiment_config_schema.py
@@ -1,0 +1,42 @@
+from __future__ import annotations
+
+from typing import Optional
+
+from pydantic import BaseModel, validator
+
+from .system_config_schema import SystemConfig
+from .scoring_provider_schema import ScoringProvider
+
+
+class ExperimentConfig(BaseModel):
+    """Schema for the experiment_config table."""
+
+    id: Optional[int] = None
+    name: str
+    description: Optional[str] = None
+    system_manager_id: Optional[int] = None
+    scoring_model_id: Optional[int] = None
+
+    system_manager: Optional[SystemConfig] = None
+    scoring_model: Optional[ScoringProvider] = None
+
+    table_name: str = "experiment_config"
+
+    @validator("system_manager", always=True)
+    def _sync_system_manager_id(cls, v, values):
+        if v is not None and values.get("system_manager_id") is None:
+            values["system_manager_id"] = getattr(v, "id", None)
+        return v
+
+    @validator("scoring_model", always=True)
+    def _sync_scoring_model_id(cls, v, values):
+        if v is not None and values.get("scoring_model_id") is None:
+            values["scoring_model_id"] = getattr(v, "id", None)
+        return v
+
+    def model_dump(self) -> dict:  # pragma: no cover - simple wrapper
+        data = self.dict()
+        for field in ("system_manager", "scoring_model"):
+            if data.get(field) is not None:
+                data[field] = data[field].model_dump()
+        return data

--- a/app/schemas/file_path_schema.py
+++ b/app/schemas/file_path_schema.py
@@ -1,0 +1,24 @@
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Optional
+
+from pydantic import BaseModel, validator
+
+
+class FilePath(BaseModel):
+    """Schema for file paths tracked in the database."""
+
+    artifact_path: Path
+
+    table_name: str = "file_path"
+
+    @validator("artifact_path")
+    def _check_path(cls, v: Path) -> Path:
+        p = Path(v)
+        if not p.is_absolute() and ".." in p.parts:
+            raise ValueError("artifact_path must be absolute or project relative")
+        return p
+
+    def model_dump(self) -> dict:  # pragma: no cover - simple wrapper
+        return {"artifact_path": str(self.artifact_path)}

--- a/app/schemas/prompt_generator_schema.py
+++ b/app/schemas/prompt_generator_schema.py
@@ -1,0 +1,64 @@
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Optional
+
+from pydantic import BaseModel, validator
+
+from .agent_prompt_schema import AgentPrompt
+from .system_prompt_schema import SystemPrompt
+from .context_provider_schema import ContextProvider
+
+
+class PromptGenerator(BaseModel):
+    """Schema for the prompt_generator table."""
+
+    id: Optional[int] = None
+    name: str
+    description: Optional[str] = None
+    agent_prompt_id: Optional[int] = None
+    system_prompt_id: Optional[int] = None
+    content_provider_id: Optional[int] = None
+
+    agent_prompt: Optional[AgentPrompt] = None
+    system_prompt: Optional[SystemPrompt] = None
+    content_provider: Optional[ContextProvider] = None
+    artifact_path: Optional[Path] = None
+
+    table_name: str = "prompt_generator"
+
+    @validator("agent_prompt", always=True)
+    def _sync_agent_prompt_id(cls, v, values):
+        if v is not None and values.get("agent_prompt_id") is None:
+            values["agent_prompt_id"] = getattr(v, "id", None)
+        return v
+
+    @validator("system_prompt", always=True)
+    def _sync_system_prompt_id(cls, v, values):
+        if v is not None and values.get("system_prompt_id") is None:
+            values["system_prompt_id"] = getattr(v, "id", None)
+        return v
+
+    @validator("content_provider", always=True)
+    def _sync_content_provider_id(cls, v, values):
+        if v is not None and values.get("content_provider_id") is None:
+            values["content_provider_id"] = getattr(v, "id", None)
+        return v
+
+    @validator("artifact_path")
+    def _check_path(cls, v: Optional[Path]) -> Optional[Path]:
+        if v is None:
+            return v
+        p = Path(v)
+        if not p.is_absolute() and ".." in p.parts:
+            raise ValueError("artifact_path must be absolute or project relative")
+        return p
+
+    def model_dump(self) -> dict:  # pragma: no cover - simple wrapper
+        data = self.dict()
+        for field in ("agent_prompt", "system_prompt", "content_provider"):
+            if data.get(field) is not None:
+                data[field] = data[field].model_dump()
+        if data.get("artifact_path") is not None:
+            data["artifact_path"] = str(data["artifact_path"])
+        return data

--- a/app/schemas/scoring_provider_schema.py
+++ b/app/schemas/scoring_provider_schema.py
@@ -1,0 +1,32 @@
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Optional
+
+from pydantic import BaseModel, validator
+
+
+class ScoringProvider(BaseModel):
+    """Schema for the scoring_provider table."""
+
+    id: Optional[int] = None
+    name: str
+    description: Optional[str] = None
+    artifact_path: Optional[Path] = None
+
+    table_name: str = "scoring_provider"
+
+    @validator("artifact_path")
+    def _check_path(cls, v: Optional[Path]) -> Optional[Path]:
+        if v is None:
+            return v
+        p = Path(v)
+        if not p.is_absolute() and ".." in p.parts:
+            raise ValueError("artifact_path must be absolute or project relative")
+        return p
+
+    def model_dump(self) -> dict:  # pragma: no cover - simple wrapper
+        data = self.dict()
+        if data.get("artifact_path") is not None:
+            data["artifact_path"] = str(data["artifact_path"])
+        return data

--- a/app/schemas/series_schema.py
+++ b/app/schemas/series_schema.py
@@ -1,0 +1,29 @@
+from __future__ import annotations
+
+from typing import Optional
+
+from pydantic import BaseModel, validator
+
+from .experiment_config_schema import ExperimentConfig
+
+
+class Series(BaseModel):
+    """Schema for the series table."""
+
+    id: Optional[int] = None
+    experiment_config_id: Optional[int] = None
+    experiment_config: Optional[ExperimentConfig] = None
+
+    table_name: str = "series"
+
+    @validator("experiment_config", always=True)
+    def _sync_experiment_id(cls, v, values):
+        if v is not None and values.get("experiment_config_id") is None:
+            values["experiment_config_id"] = getattr(v, "id", None)
+        return v
+
+    def model_dump(self) -> dict:  # pragma: no cover - simple wrapper
+        data = self.dict()
+        if data.get("experiment_config") is not None:
+            data["experiment_config"] = data["experiment_config"].model_dump()
+        return data

--- a/app/schemas/state_manager_schema.py
+++ b/app/schemas/state_manager_schema.py
@@ -1,0 +1,35 @@
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Optional
+
+from pydantic import BaseModel, validator
+
+
+class StateManager(BaseModel):
+    """Schema for the state_manager table."""
+
+    id: Optional[int] = None
+    name: str
+    description: Optional[str] = None
+    system_state: Optional[str] = None
+    system_type: Optional[str] = None
+    agent_id: Optional[int] = None
+    artifact_path: Optional[Path] = None
+
+    table_name: str = "state_manager"
+
+    @validator("artifact_path")
+    def _check_path(cls, v: Optional[Path]) -> Optional[Path]:
+        if v is None:
+            return v
+        p = Path(v)
+        if not p.is_absolute() and ".." in p.parts:
+            raise ValueError("artifact_path must be absolute or project relative")
+        return p
+
+    def model_dump(self) -> dict:  # pragma: no cover - simple wrapper
+        data = self.dict()
+        if data.get("artifact_path") is not None:
+            data["artifact_path"] = str(data["artifact_path"])
+        return data

--- a/app/schemas/system_config_schema.py
+++ b/app/schemas/system_config_schema.py
@@ -1,0 +1,43 @@
+from __future__ import annotations
+
+from typing import Optional
+
+from pydantic import BaseModel, validator
+
+from .state_manager_schema import StateManager
+from .scoring_provider_schema import ScoringProvider
+
+
+class SystemConfig(BaseModel):
+    """Schema for the system_config table."""
+
+    id: Optional[int] = None
+    name: str
+    description: Optional[str] = None
+    system_type: Optional[str] = None
+    state_manager_id: Optional[int] = None
+    scoring_model_id: Optional[int] = None
+
+    state_manager: Optional[StateManager] = None
+    scoring_model: Optional[ScoringProvider] = None
+
+    table_name: str = "system_config"
+
+    @validator("state_manager", always=True)
+    def _sync_state_manager_id(cls, v, values):
+        if v is not None and values.get("state_manager_id") is None:
+            values["state_manager_id"] = getattr(v, "id", None)
+        return v
+
+    @validator("scoring_model", always=True)
+    def _sync_scoring_model_id(cls, v, values):
+        if v is not None and values.get("scoring_model_id") is None:
+            values["scoring_model_id"] = getattr(v, "id", None)
+        return v
+
+    def model_dump(self) -> dict:  # pragma: no cover - simple wrapper
+        data = self.dict()
+        for field in ("state_manager", "scoring_model"):
+            if data.get(field) is not None:
+                data[field] = data[field].model_dump()
+        return data

--- a/app/schemas/system_prompt_schema.py
+++ b/app/schemas/system_prompt_schema.py
@@ -1,0 +1,33 @@
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Optional
+
+from pydantic import BaseModel, validator
+
+
+class SystemPrompt(BaseModel):
+    """Schema for the system_prompt table."""
+
+    id: Optional[int] = None
+    name: str
+    description: Optional[str] = None
+    system_type: Optional[str] = None
+    artifact_path: Optional[Path] = None
+
+    table_name: str = "system_prompt"
+
+    @validator("artifact_path")
+    def _check_path(cls, v: Optional[Path]) -> Optional[Path]:
+        if v is None:
+            return v
+        p = Path(v)
+        if not p.is_absolute() and ".." in p.parts:
+            raise ValueError("artifact_path must be absolute or project relative")
+        return p
+
+    def model_dump(self) -> dict:  # pragma: no cover - simple wrapper
+        data = self.dict()
+        if data.get("artifact_path") is not None:
+            data["artifact_path"] = str(data["artifact_path"])
+        return data

--- a/app/schemas/tooling_provider_schema.py
+++ b/app/schemas/tooling_provider_schema.py
@@ -1,0 +1,32 @@
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Optional
+
+from pydantic import BaseModel, validator
+
+
+class ToolingProvider(BaseModel):
+    """Schema for the tooling_provider table."""
+
+    id: Optional[int] = None
+    name: str
+    description: Optional[str] = None
+    artifact_path: Optional[Path] = None
+
+    table_name: str = "tooling_provider"
+
+    @validator("artifact_path")
+    def _check_path(cls, v: Optional[Path]) -> Optional[Path]:
+        if v is None:
+            return v
+        p = Path(v)
+        if not p.is_absolute() and ".." in p.parts:
+            raise ValueError("artifact_path must be absolute or project relative")
+        return p
+
+    def model_dump(self) -> dict:  # pragma: no cover - simple wrapper
+        data = self.dict()
+        if data.get("artifact_path") is not None:
+            data["artifact_path"] = str(data["artifact_path"])
+        return data

--- a/app/utilities/schema/__init__.py
+++ b/app/utilities/schema/__init__.py
@@ -1,0 +1,3 @@
+from .create_schema import initialize_database, create_tables, load_seed_data
+
+__all__ = ["initialize_database", "create_tables", "load_seed_data"]

--- a/app/utilities/schema/create_schema.py
+++ b/app/utilities/schema/create_schema.py
@@ -1,0 +1,122 @@
+from __future__ import annotations
+
+import json
+import sqlite3
+from pathlib import Path
+from typing import Iterable, Type, Protocol, Any
+
+from pydantic import BaseModel
+
+from app.schemas import (
+    AgentEngine,
+    AgentPrompt,
+    SystemPrompt,
+    ContextProvider,
+    ToolingProvider,
+    FilePath,
+    AgentConfig,
+    PromptGenerator,
+    ScoringProvider,
+    StateManager,
+    SystemConfig,
+    ExperimentConfig,
+    Series,
+)
+from app.utilities import db
+
+class SchemaProtocol(Protocol):
+    table_name: str
+    __fields__: dict
+
+    def __init__(self, **data: object) -> None:
+        ...
+
+    def model_dump(self) -> dict:
+        ...
+
+
+SchemaModel = Type[Any]
+
+SCHEMAS: tuple[SchemaModel, ...] = (
+    AgentEngine,
+    AgentPrompt,
+    SystemPrompt,
+    ContextProvider,
+    ToolingProvider,
+    FilePath,
+    AgentConfig,
+    PromptGenerator,
+    ScoringProvider,
+    StateManager,
+    SystemConfig,
+    ExperimentConfig,
+    Series,
+)
+
+TABLE_MAP = {model.table_name: model for model in SCHEMAS}
+
+
+_TYPE_MAP = {
+    int: "INTEGER",
+    str: "TEXT",
+    float: "REAL",
+}
+
+
+def _sqlite_type(py_type: Type) -> str:
+    return _TYPE_MAP.get(py_type, "TEXT")
+
+
+def create_tables(conn: sqlite3.Connection) -> None:
+    cur = conn.cursor()
+    for model in SCHEMAS:
+        columns = []
+        for name, field in model.__fields__.items():
+            if name == "table_name":
+                continue
+            column = f"{name}"
+            col_type = _sqlite_type(field.type_)
+            if name == "id" and field.required is False:
+                columns.append(f"{column} INTEGER PRIMARY KEY")
+            else:
+                columns.append(f"{column} {col_type}")
+        col_sql = ",".join(columns)
+        cur.execute(f"CREATE TABLE IF NOT EXISTS {model.table_name} ({col_sql})")
+    conn.commit()
+
+
+def load_seed_data(
+    conn: sqlite3.Connection, seed_dir: Path | str = "experiments/config/seed"
+) -> None:
+    seed_path = Path(seed_dir)
+    if not seed_path.exists():
+        return
+    cur = conn.cursor()
+    for file in seed_path.glob("*.json"):
+        model = TABLE_MAP.get(file.stem)
+        if model is None:
+            continue
+        entries = json.loads(file.read_text())
+        if isinstance(entries, dict):
+            entries = [entries]
+        for entry in entries:
+            obj = model(**entry)
+            data = obj.model_dump()
+            cols = ",".join(data.keys())
+            placeholders = ",".join(["?"] * len(data))
+            cur.execute(
+                f"INSERT INTO {model.table_name} ({cols}) VALUES ({placeholders})",
+                list(data.values()),
+            )
+    conn.commit()
+
+
+def initialize_database() -> sqlite3.Connection:
+    conn = db.get_connection()
+    create_tables(conn)
+    load_seed_data(conn)
+    return conn
+
+
+if __name__ == "__main__":  # pragma: no cover - manual invocation
+    initialize_database()

--- a/experiments/config/seed/agent_engine.json
+++ b/experiments/config/seed/agent_engine.json
@@ -1,0 +1,10 @@
+[
+  {
+    "id": 1,
+    "name": "basic",
+    "description": "Basic test engine",
+    "model": "gpt-4",
+    "engine_config": "{}",
+    "artifact_path": "engines/basic.json"
+  }
+]

--- a/experiments/config/seed/agent_prompt.json
+++ b/experiments/config/seed/agent_prompt.json
@@ -1,0 +1,10 @@
+[
+  {
+    "id": 1,
+    "name": "default_agent",
+    "description": "Agent prompt",
+    "agent_role": "generator",
+    "system_type": "default",
+    "artifact_path": "prompts/agent.txt"
+  }
+]

--- a/experiments/config/seed/context_provider.json
+++ b/experiments/config/seed/context_provider.json
@@ -1,0 +1,9 @@
+[
+  {
+    "id": 1,
+    "name": "basic_context",
+    "description": "Provides context",
+    "system_type": "default",
+    "tooling_provider_id": 1
+  }
+]

--- a/experiments/config/seed/experiment_config.json
+++ b/experiments/config/seed/experiment_config.json
@@ -1,0 +1,9 @@
+[
+  {
+    "id": 1,
+    "name": "basic_experiment",
+    "description": "Experiment config",
+    "system_manager_id": 1,
+    "scoring_model_id": 1
+  }
+]

--- a/experiments/config/seed/prompt_generator.json
+++ b/experiments/config/seed/prompt_generator.json
@@ -1,0 +1,11 @@
+[
+  {
+    "id": 1,
+    "name": "basic_generator",
+    "description": "Generates prompts",
+    "agent_prompt_id": 1,
+    "system_prompt_id": 1,
+    "content_provider_id": 1,
+    "artifact_path": "generators/basic.py"
+  }
+]

--- a/experiments/config/seed/scoring_provider.json
+++ b/experiments/config/seed/scoring_provider.json
@@ -1,0 +1,8 @@
+[
+  {
+    "id": 1,
+    "name": "basic_score",
+    "description": "Basic scoring",
+    "artifact_path": "scoring/basic.py"
+  }
+]

--- a/experiments/config/seed/series.json
+++ b/experiments/config/seed/series.json
@@ -1,0 +1,6 @@
+[
+  {
+    "id": 1,
+    "experiment_config_id": 1
+  }
+]

--- a/experiments/config/seed/state_manager.json
+++ b/experiments/config/seed/state_manager.json
@@ -1,0 +1,11 @@
+[
+  {
+    "id": 1,
+    "name": "basic_state",
+    "description": "Tracks states",
+    "system_state": "init",
+    "system_type": "default",
+    "agent_id": 1,
+    "artifact_path": "state/basic.py"
+  }
+]

--- a/experiments/config/seed/system_config.json
+++ b/experiments/config/seed/system_config.json
@@ -1,0 +1,10 @@
+[
+  {
+    "id": 1,
+    "name": "basic_system",
+    "description": "System config",
+    "system_type": "default",
+    "state_manager_id": 1,
+    "scoring_model_id": 1
+  }
+]

--- a/experiments/config/seed/system_prompt.json
+++ b/experiments/config/seed/system_prompt.json
@@ -1,0 +1,9 @@
+[
+  {
+    "id": 1,
+    "name": "default_system",
+    "description": "System prompt",
+    "system_type": "default",
+    "artifact_path": "prompts/system.txt"
+  }
+]

--- a/experiments/config/seed/tooling_provider.json
+++ b/experiments/config/seed/tooling_provider.json
@@ -1,0 +1,8 @@
+[
+  {
+    "id": 1,
+    "name": "shell",
+    "description": "Shell execution provider",
+    "artifact_path": "tools/shell.py"
+  }
+]

--- a/schema_demo.ipynb
+++ b/schema_demo.ipynb
@@ -1,0 +1,39 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from app.utilities.schema import initialize_database\n",
+    "conn = initialize_database()\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "tables = ['agent_engine', 'agent_prompt', 'system_prompt']\n",
+    "for t in tables:\n",
+    "    rows = conn.execute(f'SELECT * FROM {t}').fetchall()\n",
+    "    print(t, rows)\n"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python",
+   "version": "3.11"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}


### PR DESCRIPTION
## Summary
- add pydantic schema models for persistence layer
- create schema creation and seeding utility
- provide example seed data and demo notebook

## Testing
- `black . --check`
- `ruff check .` *(fails: F811 in utilities.ipynb)*
- `mypy .`
- `radon cc -s app/schemas/agent_engine_schema.py` *(fails: command not found)*
- `pytest -q` *(fails: command not found)*