### PR TITLE
[Phase 11] Implement Mediator agent

### DIFF
--- a/app/extensions/agents/__init__.py
+++ b/app/extensions/agents/__init__.py
@@ -1,10 +1,12 @@
 from .dummy_agent import DummyAgent
 from .generator_agent import GeneratorAgent
 from .evaluator_agent import EvaluatorAgent
+from .mediator_agent import MediatorAgent
 from ...registries.agents import AGENT_REGISTRY
 
 AGENT_REGISTRY.register("dummy", DummyAgent)
 AGENT_REGISTRY.register("generator", GeneratorAgent)
 AGENT_REGISTRY.register("evaluator", EvaluatorAgent)
+AGENT_REGISTRY.register("mediator", MediatorAgent)
 
-__all__ = ["DummyAgent", "GeneratorAgent", "EvaluatorAgent"]
+__all__ = ["DummyAgent", "GeneratorAgent", "EvaluatorAgent", "MediatorAgent"]

--- a/app/extensions/agents/mediator_agent.py
+++ b/app/extensions/agents/mediator_agent.py
@@ -1,0 +1,97 @@
+from __future__ import annotations
+
+from typing import List, Any
+
+from ...abstract_classes.agent_base import AgentBase
+from ...enums.agent_enums import AgentRole
+from ...factories.logging_provider import (
+    ConversationLog,
+    ErrorLog,
+    LoggingProvider,
+)
+from ...utilities.snapshots.snapshot_writer import SnapshotWriter
+
+
+class MediatorAgent(AgentBase):
+    """Agent that reconciles discrepancies between generator and evaluator outputs."""
+
+    def __init__(
+        self,
+        target: str = "generated.py",
+        logger: LoggingProvider | None = None,
+        snapshot_writer: SnapshotWriter | None = None,
+    ) -> None:
+        super().__init__(logger)
+        self.target = target
+        self.snapshot_writer = snapshot_writer or SnapshotWriter()
+        self.conversation_logs: List[ConversationLog] = []
+        self.error_logs: List[ErrorLog] = []
+
+    def _run_agent_logic(self, *args, **kwargs) -> None:
+        code: str | None = kwargs.get("generator_output")
+        metrics: dict[str, Any] | None = kwargs.get("evaluation_metrics")
+
+        if code is None or metrics is None:
+            err = ErrorLog(
+                experiment_id="exp",
+                round=0,
+                error_type="ValueError",
+                message="Missing generator output or evaluation metrics",
+                file_path=self.target,
+            )
+            self.error_logs.append(err)
+            self.log_error(err)
+            return
+
+        lint_errors = int(metrics.get("lint_errors", 0))
+        maintainability = float(metrics.get("maintainability_index", 100.0))
+        complexity = float(metrics.get("cyclomatic_complexity", 0.0))
+
+        recommendations: List[str] = []
+        if lint_errors > 0:
+            recommendations.append("Resolve lint errors")
+        if maintainability < 70:
+            recommendations.append("Increase maintainability")
+        if complexity > 10:
+            recommendations.append("Reduce complexity")
+
+        rec_text = "; ".join(recommendations)
+        conv = ConversationLog(
+            experiment_id="exp",
+            round=0,
+            agent_role=AgentRole.MEDIATOR,
+            target=self.target,
+            content=rec_text,
+            originating_agent="mediator",
+            intervention=bool(recommendations),
+            intervention_type="mediation" if recommendations else None,
+            intervention_reason="evaluation discrepancy" if recommendations else None,
+        )
+        self.conversation_logs.append(conv)
+
+        try:
+            self.log_conversation(conv)
+        except Exception as exc:  # pragma: no cover - db write failure
+            err = ErrorLog(
+                experiment_id="exp",
+                round=0,
+                error_type=type(exc).__name__,
+                message=str(exc),
+                file_path=self.target,
+            )
+            self.error_logs.append(err)
+            self.log_error(err)
+
+        after = code
+        if rec_text:
+            after = code + f"\n# Mediator Recommendation: {rec_text}"
+
+        self.snapshot_writer.write_snapshot(
+            experiment_id="exp",
+            round=0,
+            file_path=self.target,
+            before=code,
+            after=after,
+            symbol=self.target,
+            agent_role=AgentRole.MEDIATOR,
+        )

--- a/mediator_agent_demo.ipynb
+++ b/mediator_agent_demo.ipynb
@@ -24,11 +24,11 @@
     "from importlib import import_module\n",
     "from app.factories.agent import AgentFactory\n",
     "\n",
-    "import_module('app.extensions.agents')\n",
+    "import_module(\"app.extensions.agents\")\n",
     "\n",
-    "code = 'def add(x, y):\\n    return x + y'\n",
-    "metrics = {'lint_errors': 1, 'maintainability_index': 60}\n",
-    "agent = AgentFactory.create('mediator', target='demo.py')\n",
+    "code = \"def add(x, y):\\n    return x + y\"\n",
+    "metrics = {\"lint_errors\": 1, \"maintainability_index\": 60}\n",
+    "agent = AgentFactory.create(\"mediator\", target=\"demo.py\")\n",
     "agent.run(generator_output=code, evaluation_metrics=metrics)\n",
     "log = agent.conversation_logs[0]"
    ]
@@ -38,9 +38,17 @@
    "execution_count": 2,
    "id": "c2",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Mediator recommendation: Resolve lint errors; Increase maintainability\n"
+     ]
+    }
+   ],
    "source": [
-    "print('Mediator recommendation:', log.content)"
+    "print(\"Mediator recommendation:\", log.content)"
    ]
   }
  ],
@@ -51,7 +59,10 @@
    "name": "python3"
   },
   "language_info": {
-   "codemirror_mode": {"name": "ipython", "version": 3},
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
    "file_extension": ".py",
    "mimetype": "text/x-python",
    "name": "python",

--- a/tests/notebooks/mediator_agent_demo.ipynb
+++ b/tests/notebooks/mediator_agent_demo.ipynb
@@ -1,0 +1,65 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Mediator Agent Demo"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "This notebook demonstrates running the `MediatorAgent` to resolve conflicts between generator and evaluator outputs."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "id": "c1",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from importlib import import_module\n",
+    "from app.factories.agent import AgentFactory\n",
+    "\n",
+    "import_module('app.extensions.agents')\n",
+    "\n",
+    "code = 'def add(x, y):\\n    return x + y'\n",
+    "metrics = {'lint_errors': 1, 'maintainability_index': 60}\n",
+    "agent = AgentFactory.create('mediator', target='demo.py')\n",
+    "agent.run(generator_output=code, evaluation_metrics=metrics)\n",
+    "log = agent.conversation_logs[0]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "id": "c2",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "print('Mediator recommendation:', log.content)"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": ".venv",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {"name": "ipython", "version": 3},
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.12.6"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/tests/test_mediator_agent.py
+++ b/tests/test_mediator_agent.py
@@ -1,0 +1,53 @@
+import unittest
+from importlib import import_module
+from unittest.mock import patch
+
+from app.factories.agent import AgentFactory
+
+
+class MediatorAgentTests(unittest.TestCase):
+    def setUp(self):
+        import_module("app.extensions.agents")
+
+    @patch("app.extensions.agents.mediator_agent.SnapshotWriter.write_snapshot")
+    @patch("app.extensions.agents.mediator_agent.LoggingProvider.log_conversation")
+    @patch("app.extensions.agents.mediator_agent.LoggingProvider.log_error")
+    def test_mediator_with_discrepancy(self, log_error, log_conv, snap):
+        agent = AgentFactory.create("mediator", target="demo.py")
+        agent.run(
+            generator_output="x=1",
+            evaluation_metrics={"lint_errors": 1, "maintainability_index": 60},
+        )
+        self.assertEqual(len(agent.conversation_logs), 1)
+        self.assertTrue(agent.conversation_logs[0].intervention)
+        self.assertIn("Resolve lint errors", agent.conversation_logs[0].content)
+        snap.assert_called_once()
+        log_conv.assert_called_once()
+        log_error.assert_not_called()
+
+    @patch("app.extensions.agents.mediator_agent.LoggingProvider.log_conversation")
+    @patch("app.extensions.agents.mediator_agent.LoggingProvider.log_error")
+    def test_mediator_no_discrepancy(self, log_error, log_conv):
+        agent = AgentFactory.create("mediator", target="demo.py")
+        agent.run(
+            generator_output="x=1",
+            evaluation_metrics={"lint_errors": 0, "maintainability_index": 90},
+        )
+        self.assertEqual(len(agent.conversation_logs), 1)
+        self.assertFalse(agent.conversation_logs[0].intervention)
+        self.assertEqual(agent.conversation_logs[0].content, "")
+        log_conv.assert_called_once()
+        log_error.assert_not_called()
+
+    @patch("app.extensions.agents.mediator_agent.LoggingProvider.log_conversation")
+    @patch("app.extensions.agents.mediator_agent.LoggingProvider.log_error")
+    def test_mediator_missing_metrics(self, log_error, log_conv):
+        agent = AgentFactory.create("mediator", target="demo.py")
+        agent.run(generator_output="x=1", evaluation_metrics=None)
+        self.assertEqual(len(agent.error_logs), 1)
+        log_conv.assert_not_called()
+        log_error.assert_called_once()
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- implement MediatorAgent for reconciling generator/evaluator results
- register MediatorAgent
- test MediatorAgent logic and conflict handling
- add Mediator demo notebook

## Testing
- `black . --quiet`
- `mypy .` *(fails: "model_dump" undefined in superclass)*
- `python -m radon cc app/extensions/agents/mediator_agent.py -s` *(fails: No module named radon)*
- `ruff check .`
- `pytest -q` *(fails: command not found)*