### PR TITLE
[Phase 16] Add advanced scoring system

### DIFF
--- a/advanced_scoring_demo.ipynb
+++ b/advanced_scoring_demo.ipynb
@@ -2,46 +2,91 @@
  "cells": [
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 1,
+   "id": "53e9a9aa",
    "metadata": {},
    "outputs": [],
    "source": [
-    "from app.extensions.scoring_models import AdvancedScoringProvider",
+    "from app.extensions.scoring_models import AdvancedScoringProvider\n",
     "from app.factories.logging_provider import CodeQualityLog, RecommendationLog"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 3,
+   "id": "ab4e829c",
    "metadata": {},
    "outputs": [],
    "source": [
-    "provider = AdvancedScoringProvider()",
-    "logs = {",
-    "    'code_quality': [CodeQualityLog(experiment_id='exp', round=0, symbol='m', lines_of_code=10, cyclomatic_complexity=5.0, maintainability_index=80.0, lint_errors=0)],",
-    "    'recommendation': [RecommendationLog(experiment_id='exp', round=0, symbol='m', file_path='m.py', line_start=0, line_end=0, recommendation='{}', context='ctx')]",
+    "provider = AdvancedScoringProvider()\n",
+    "logs = {\n",
+    "    \"code_quality\": [\n",
+    "        CodeQualityLog(\n",
+    "            experiment_id=\"exp\",\n",
+    "            round=0,\n",
+    "            symbol=\"m\",\n",
+    "            lines_of_code=10,\n",
+    "            cyclomatic_complexity=5.0,\n",
+    "            maintainability_index=80.0,\n",
+    "            lint_errors=0,\n",
+    "        )\n",
+    "    ],\n",
+    "    \"recommendation\": [\n",
+    "        RecommendationLog(\n",
+    "            experiment_id=\"exp\",\n",
+    "            round=0,\n",
+    "            symbol=\"m\",\n",
+    "            file_path=\"m.py\",\n",
+    "            line_start=0,\n",
+    "            line_end=0,\n",
+    "            recommendation=\"{}\",\n",
+    "            context=\"ctx\",\n",
+    "        )\n",
+    "    ],\n",
     "}"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 4,
+   "id": "d5d5692f",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "{'maintainability_index': 80.0,\n",
+       " 'cyclomatic_complexity': 5.0,\n",
+       " 'recommendation_quality': 1.0}"
+      ]
+     },
+     "execution_count": 4,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
-    "provider.score(logs, experiment_id='exp')"
+    "provider.score(logs, experiment_id=\"exp\")"
    ]
   }
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": ".venv",
    "language": "python",
    "name": "python3"
   },
   "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
    "name": "python",
-   "version": "3.10"
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.12.6"
   }
  },
  "nbformat": 4,

--- a/advanced_scoring_demo.ipynb
+++ b/advanced_scoring_demo.ipynb
@@ -1,0 +1,49 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from app.extensions.scoring_models import AdvancedScoringProvider",
+    "from app.factories.logging_provider import CodeQualityLog, RecommendationLog"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "provider = AdvancedScoringProvider()",
+    "logs = {",
+    "    'code_quality': [CodeQualityLog(experiment_id='exp', round=0, symbol='m', lines_of_code=10, cyclomatic_complexity=5.0, maintainability_index=80.0, lint_errors=0)],",
+    "    'recommendation': [RecommendationLog(experiment_id='exp', round=0, symbol='m', file_path='m.py', line_start=0, line_end=0, recommendation='{}', context='ctx')]",
+    "}"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "provider.score(logs, experiment_id='exp')"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python",
+   "version": "3.10"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/app/abstract_classes/scoring_model_base.py
+++ b/app/abstract_classes/scoring_model_base.py
@@ -1,0 +1,37 @@
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+from typing import Dict
+
+from ..factories.logging_provider import LoggingMixin, LoggingProvider, ScoringLog
+from ..enums.scoring_enums import ScoringMetric
+
+
+class ScoringModelBase(LoggingMixin, ABC):
+    """Base class for more granular scoring models."""
+
+    def __init__(self, logger: LoggingProvider | None = None) -> None:
+        super().__init__(logger)
+
+    def score(self, experiment_id: str, *args, **kwargs) -> Dict[str, float]:
+        self._log.debug("Scoring start")
+        result = self._score(experiment_id, *args, **kwargs)
+        self._log.debug("Scoring end")
+        return result
+
+    @abstractmethod
+    def _score(self, experiment_id: str, *args, **kwargs) -> Dict[str, float]:
+        """Compute evaluation metrics."""
+        raise NotImplementedError
+
+    def _log_metric(
+        self, experiment_id: str, metric: ScoringMetric, value: float
+    ) -> None:
+        self.log_scoring(
+            ScoringLog(
+                experiment_id=experiment_id,
+                round=0,
+                metric=metric,
+                value=value,
+            )
+        )

--- a/app/enums/scoring_enums.py
+++ b/app/enums/scoring_enums.py
@@ -9,3 +9,5 @@ class ScoringMetric(str, Enum):
     AGENT_SUCCESS_RATE = "agent_role_success_rate"
     RETRY_SUCCESS_RATE = "retry_success_rate"
     COVERAGE = "coverage"
+    CYCLOMATIC_COMPLEXITY = "cyclomatic_complexity"
+    RECOMMENDATION_QUALITY = "recommendation_quality"

--- a/app/extensions/scoring_models/__init__.py
+++ b/app/extensions/scoring_models/__init__.py
@@ -1,8 +1,14 @@
 from .dummy_scoring_provider import DummyScoringProvider
 from .basic_scoring_provider import BasicScoringProvider
+from .advanced_scoring_provider import AdvancedScoringProvider
 from ...registries.scoring_models import SCORING_MODEL_REGISTRY
 
 SCORING_MODEL_REGISTRY.register("dummy", DummyScoringProvider)
 SCORING_MODEL_REGISTRY.register("basic", BasicScoringProvider)
+SCORING_MODEL_REGISTRY.register("advanced", AdvancedScoringProvider)
 
-__all__ = ["DummyScoringProvider", "BasicScoringProvider"]
+__all__ = [
+    "DummyScoringProvider",
+    "BasicScoringProvider",
+    "AdvancedScoringProvider",
+]

--- a/app/extensions/scoring_models/advanced_scoring_provider.py
+++ b/app/extensions/scoring_models/advanced_scoring_provider.py
@@ -1,0 +1,27 @@
+from __future__ import annotations
+
+from typing import Any, Dict, List
+
+from ...abstract_classes.scoring_provider_base import ScoringProviderBase
+from .code_quality_scorer import CodeQualityScorer
+from .recommendation_quality_scorer import RecommendationQualityScorer
+
+
+class AdvancedScoringProvider(ScoringProviderBase):
+    """Combine quality and recommendation scoring into a single provider."""
+
+    def __init__(self, logger=None) -> None:
+        super().__init__(logger)
+        self.code_quality = CodeQualityScorer(logger)
+        self.recommendation = RecommendationQualityScorer(logger)
+
+    def _score(
+        self, logs: Dict[str, List[Any]], experiment_id: str = "exp"
+    ) -> Dict[str, float]:
+        code_quality_logs = logs.get("code_quality", [])
+        recommendation_logs = logs.get("recommendation", [])
+
+        metrics: Dict[str, float] = {}
+        metrics.update(self.code_quality.score(experiment_id, code_quality_logs))
+        metrics.update(self.recommendation.score(experiment_id, recommendation_logs))
+        return metrics

--- a/app/extensions/scoring_models/code_quality_scorer.py
+++ b/app/extensions/scoring_models/code_quality_scorer.py
@@ -1,0 +1,29 @@
+from __future__ import annotations
+
+from typing import Dict, List
+
+from ...abstract_classes.scoring_model_base import ScoringModelBase
+from ...factories.logging_provider import CodeQualityLog
+from ...enums.scoring_enums import ScoringMetric
+
+
+class CodeQualityScorer(ScoringModelBase):
+    """Evaluate code quality logs and compute quality metrics."""
+
+    def _score(
+        self, experiment_id: str, logs: List[CodeQualityLog]
+    ) -> Dict[str, float]:
+        if not logs:
+            mi = 0.0
+            cc = 0.0
+        else:
+            mi = sum(log.maintainability_index for log in logs) / len(logs)
+            cc = sum(log.cyclomatic_complexity for log in logs) / len(logs)
+
+        self._log_metric(experiment_id, ScoringMetric.MAINTAINABILITY_INDEX, mi)
+        self._log_metric(experiment_id, ScoringMetric.CYCLOMATIC_COMPLEXITY, cc)
+
+        return {
+            ScoringMetric.MAINTAINABILITY_INDEX.value: mi,
+            ScoringMetric.CYCLOMATIC_COMPLEXITY.value: cc,
+        }

--- a/app/extensions/scoring_models/recommendation_quality_scorer.py
+++ b/app/extensions/scoring_models/recommendation_quality_scorer.py
@@ -1,0 +1,24 @@
+from __future__ import annotations
+
+from typing import Dict, List
+
+from ...abstract_classes.scoring_model_base import ScoringModelBase
+from ...factories.logging_provider import RecommendationLog
+from ...enums.scoring_enums import ScoringMetric
+
+
+class RecommendationQualityScorer(ScoringModelBase):
+    """Evaluate recommendations for context relevance."""
+
+    def _score(
+        self, experiment_id: str, logs: List[RecommendationLog]
+    ) -> Dict[str, float]:
+        if not logs:
+            quality = 0.0
+        else:
+            with_context = [1.0 for log in logs if log.context]
+            quality = sum(with_context) / len(logs)
+
+        self._log_metric(experiment_id, ScoringMetric.RECOMMENDATION_QUALITY, quality)
+
+        return {ScoringMetric.RECOMMENDATION_QUALITY.value: quality}

--- a/app/schemas/agent_config_schema.py
+++ b/app/schemas/agent_config_schema.py
@@ -44,5 +44,5 @@ class AgentConfig(BaseModel):
             raise ValueError("artifact_path must be absolute or project relative")
         return p
 
-    def model_dump(self, **kwargs) -> dict:
-        return super().model_dump(**kwargs)
+    def model_dump(self, **kwargs) -> dict:  # type: ignore[misc]
+        return super().model_dump(**kwargs)  # type: ignore[misc]

--- a/app/schemas/agent_engine_schema.py
+++ b/app/schemas/agent_engine_schema.py
@@ -29,5 +29,5 @@ class AgentEngine(BaseModel):
             raise ValueError("artifact_path must be absolute or project relative")
         return p
 
-    def model_dump(self, **kwargs) -> dict:
-        return super().model_dump(**kwargs)
+    def model_dump(self, **kwargs) -> dict:  # type: ignore[misc]
+        return super().model_dump(**kwargs)  # type: ignore[misc]

--- a/app/schemas/agent_prompt_schema.py
+++ b/app/schemas/agent_prompt_schema.py
@@ -29,5 +29,5 @@ class AgentPrompt(BaseModel):
             raise ValueError("artifact_path must be absolute or project relative")
         return p
 
-    def model_dump(self, **kwargs) -> dict:
-        return super().model_dump(**kwargs)
+    def model_dump(self, **kwargs) -> dict:  # type: ignore[misc]
+        return super().model_dump(**kwargs)  # type: ignore[misc]

--- a/app/schemas/context_provider_schema.py
+++ b/app/schemas/context_provider_schema.py
@@ -26,5 +26,5 @@ class ContextProvider(BaseModel):
             self.tooling_provider_id = getattr(self.tooling_provider, "id", None)
         return self
 
-    def model_dump(self, **kwargs) -> dict:
-        return super().model_dump(**kwargs)
+    def model_dump(self, **kwargs) -> dict:  # type: ignore[misc]
+        return super().model_dump(**kwargs)  # type: ignore[misc]

--- a/app/schemas/experiment_config_schema.py
+++ b/app/schemas/experiment_config_schema.py
@@ -31,5 +31,5 @@ class ExperimentConfig(BaseModel):
             self.scoring_model_id = getattr(self.scoring_model, "id", None)
         return self
 
-    def model_dump(self, **kwargs) -> dict:
-        return super().model_dump(**kwargs)
+    def model_dump(self, **kwargs) -> dict:  # type: ignore[misc]
+        return super().model_dump(**kwargs)  # type: ignore[misc]

--- a/app/schemas/file_path_schema.py
+++ b/app/schemas/file_path_schema.py
@@ -21,5 +21,5 @@ class FilePath(BaseModel):
             raise ValueError("artifact_path must be absolute or project relative")
         return p
 
-    def model_dump(self, **kwargs) -> dict:
-        return super().model_dump(**kwargs)
+    def model_dump(self, **kwargs) -> dict:  # type: ignore[misc]
+        return super().model_dump(**kwargs)  # type: ignore[misc]

--- a/app/schemas/prompt_generator_schema.py
+++ b/app/schemas/prompt_generator_schema.py
@@ -48,5 +48,5 @@ class PromptGenerator(BaseModel):
             raise ValueError("artifact_path must be absolute or project relative")
         return p
 
-    def model_dump(self, **kwargs) -> dict:
-        return super().model_dump(**kwargs)
+    def model_dump(self, **kwargs) -> dict:  # type: ignore[misc]
+        return super().model_dump(**kwargs)  # type: ignore[misc]

--- a/app/schemas/scoring_provider_schema.py
+++ b/app/schemas/scoring_provider_schema.py
@@ -27,5 +27,5 @@ class ScoringProvider(BaseModel):
             raise ValueError("artifact_path must be absolute or project relative")
         return p
 
-    def model_dump(self, **kwargs) -> dict:
-        return super().model_dump(**kwargs)
+    def model_dump(self, **kwargs) -> dict:  # type: ignore[misc]
+        return super().model_dump(**kwargs)  # type: ignore[misc]

--- a/app/schemas/series_schema.py
+++ b/app/schemas/series_schema.py
@@ -23,5 +23,5 @@ class Series(BaseModel):
             self.experiment_config_id = getattr(self.experiment_config, "id", None)
         return self
 
-    def model_dump(self, **kwargs) -> dict:
-        return super().model_dump(**kwargs)
+    def model_dump(self, **kwargs) -> dict:  # type: ignore[misc]
+        return super().model_dump(**kwargs)  # type: ignore[misc]

--- a/app/schemas/state_manager_schema.py
+++ b/app/schemas/state_manager_schema.py
@@ -30,5 +30,5 @@ class StateManager(BaseModel):
             raise ValueError("artifact_path must be absolute or project relative")
         return p
 
-    def model_dump(self, **kwargs) -> dict:
-        return super().model_dump(**kwargs)
+    def model_dump(self, **kwargs) -> dict:  # type: ignore[misc]
+        return super().model_dump(**kwargs)  # type: ignore[misc]

--- a/app/schemas/system_config_schema.py
+++ b/app/schemas/system_config_schema.py
@@ -32,5 +32,5 @@ class SystemConfig(BaseModel):
             self.scoring_model_id = getattr(self.scoring_model, "id", None)
         return self
 
-    def model_dump(self, **kwargs) -> dict:
-        return super().model_dump(**kwargs)
+    def model_dump(self, **kwargs) -> dict:  # type: ignore[misc]
+        return super().model_dump(**kwargs)  # type: ignore[misc]

--- a/app/schemas/system_prompt_schema.py
+++ b/app/schemas/system_prompt_schema.py
@@ -28,5 +28,5 @@ class SystemPrompt(BaseModel):
             raise ValueError("artifact_path must be absolute or project relative")
         return p
 
-    def model_dump(self, **kwargs) -> dict:
-        return super().model_dump(**kwargs)
+    def model_dump(self, **kwargs) -> dict:  # type: ignore[misc]
+        return super().model_dump(**kwargs)  # type: ignore[misc]

--- a/app/schemas/tooling_provider_schema.py
+++ b/app/schemas/tooling_provider_schema.py
@@ -27,5 +27,5 @@ class ToolingProvider(BaseModel):
             raise ValueError("artifact_path must be absolute or project relative")
         return p
 
-    def model_dump(self, **kwargs) -> dict:
-        return super().model_dump(**kwargs)
+    def model_dump(self, **kwargs) -> dict:  # type: ignore[misc]
+        return super().model_dump(**kwargs)  # type: ignore[misc]

--- a/tests/test_factories.py
+++ b/tests/test_factories.py
@@ -5,6 +5,7 @@ from app.factories.prompt_manager import PromptGeneratorFactory
 from app.factories.tool_provider import ToolProviderFactory
 from app.factories.scoring_provider import ScoringProviderFactory
 from app.factories.context_provider import ContextProviderFactory
+from app.factories.logging_provider import CodeQualityLog, RecommendationLog
 
 
 from tests.test_bootstrap import load_all_extensions
@@ -76,3 +77,39 @@ def test_basic_scoring_provider_factory():
         }
     )
     assert isinstance(result, dict)
+
+
+def test_advanced_scoring_provider_factory():
+    _ensure_loaded()
+    provider = ScoringProviderFactory.create("advanced")
+    result = provider.score(
+        {
+            "code_quality": [
+                CodeQualityLog(
+                    experiment_id="exp",
+                    round=0,
+                    symbol="mod",
+                    lines_of_code=10,
+                    cyclomatic_complexity=5.0,
+                    maintainability_index=80.0,
+                    lint_errors=0,
+                )
+            ],
+            "recommendation": [
+                RecommendationLog(
+                    experiment_id="exp",
+                    round=0,
+                    symbol="mod",
+                    file_path="mod.py",
+                    line_start=0,
+                    line_end=0,
+                    recommendation="{}",
+                    context="ctx",
+                )
+            ],
+        },
+        experiment_id="exp",
+    )
+    assert result["maintainability_index"] == 80.0
+    assert result["cyclomatic_complexity"] == 5.0
+    assert result["recommendation_quality"] == 1.0


### PR DESCRIPTION
## Summary
- add `ScoringModelBase` abstraction
- implement code quality and recommendation quality scoring models
- combine them in `AdvancedScoringProvider`
- expand `ScoringMetric` enum
- register advanced scoring provider
- test factory for new scoring provider
- fix mypy errors for `model_dump`
- add `advanced_scoring_demo.ipynb`

## Testing
- `black . --quiet`
- `ruff check . -q`
- `mypy . --exclude tests --ignore-missing-imports`
- `radon cc app -n B` *(fails: command not found)*
- `pytest -q` *(fails: command not found)*