### PR TITLE
[Phase 18] Add feedback loop infrastructure

### DIFF
--- a/app/enums/logging_enums.py
+++ b/app/enums/logging_enums.py
@@ -11,3 +11,4 @@ class LogType(str, Enum):
     CODE_QUALITY = "code_quality"
     ERROR = "error"
     RECOMMENDATION = "recommendation"
+    FEEDBACK = "feedback"

--- a/app/extensions/agents/evaluator_agent.py
+++ b/app/extensions/agents/evaluator_agent.py
@@ -11,6 +11,7 @@ from ...factories.logging_provider import (
     CodeQualityLog,
     ErrorLog,
     LoggingProvider,
+    FeedbackLog,
 )
 from ...utilities.snapshots.snapshot_writer import SnapshotWriter
 
@@ -49,6 +50,17 @@ class EvaluatorAgent(AgentBase):
         self.error_logs: List[ErrorLog] = []
 
     def _run_agent_logic(self, *args, **kwargs) -> None:
+        feedback = kwargs.get("feedback")
+        if feedback:
+            for item in feedback:
+                self.log_feedback(
+                    FeedbackLog(
+                        experiment_id="exp",
+                        round=0,
+                        source="evaluator",
+                        feedback=str(item),
+                    )
+                )
         before = Path(self.target).read_text(encoding="utf-8")
         lines = len(before.splitlines())
         complexity = 0.0

--- a/app/extensions/agents/generator_agent.py
+++ b/app/extensions/agents/generator_agent.py
@@ -11,6 +11,7 @@ from ...factories.logging_provider import (
     ErrorLog,
     PromptLog,
     LoggingProvider,
+    FeedbackLog,
 )
 from ...utilities.snapshots.snapshot_writer import SnapshotWriter
 
@@ -33,6 +34,17 @@ class GeneratorAgent(AgentBase):
         self.snapshot_writer = snapshot_writer or SnapshotWriter()
 
     def _run_agent_logic(self, *args, **kwargs) -> None:
+        feedback = kwargs.get("feedback")
+        if feedback:
+            for item in feedback:
+                self.log_feedback(
+                    FeedbackLog(
+                        experiment_id="exp",
+                        round=0,
+                        source="generator",
+                        feedback=str(item),
+                    )
+                )
         before = Path(self.target).read_text(encoding="utf-8")
         log = PromptLog(
             experiment_id="exp",

--- a/app/extensions/agents/mediator_agent.py
+++ b/app/extensions/agents/mediator_agent.py
@@ -8,6 +8,7 @@ from ...factories.logging_provider import (
     ConversationLog,
     ErrorLog,
     LoggingProvider,
+    FeedbackLog,
 )
 from ...utilities.snapshots.snapshot_writer import SnapshotWriter
 
@@ -28,6 +29,17 @@ class MediatorAgent(AgentBase):
         self.error_logs: List[ErrorLog] = []
 
     def _run_agent_logic(self, *args, **kwargs) -> None:
+        feedback = kwargs.get("feedback")
+        if feedback:
+            for item in feedback:
+                self.log_feedback(
+                    FeedbackLog(
+                        experiment_id="exp",
+                        round=0,
+                        source="mediator",
+                        feedback=str(item),
+                    )
+                )
         code: str | None = kwargs.get("generator_output")
         metrics: dict[str, Any] | None = kwargs.get("evaluation_metrics")
 

--- a/app/extensions/agents/patch_agent.py
+++ b/app/extensions/agents/patch_agent.py
@@ -11,6 +11,7 @@ from ...factories.logging_provider import (
     ConversationLog,
     ErrorLog,
     LoggingProvider,
+    FeedbackLog,
 )
 from ...factories.tool_provider import ToolProviderFactory
 from ...utilities.snapshots.snapshot_writer import SnapshotWriter
@@ -48,6 +49,18 @@ class PatchAgent(AgentBase):
         raise ValueError(f"unsupported op: {op.get('op')}")
 
     def _run_agent_logic(self, *args, **kwargs) -> None:  # noqa: C901 - small
+        feedback = kwargs.get("feedback")
+        if feedback:
+            for item in feedback:
+                self.log_feedback(
+                    FeedbackLog(
+                        experiment_id="exp",
+                        round=0,
+                        source="patch",
+                        feedback=str(item),
+                    )
+                )
+
         recs: List[ConversationLog] | None = kwargs.get("recommendations")
         if not recs:
             return

--- a/app/extensions/agents/recommendation_agent.py
+++ b/app/extensions/agents/recommendation_agent.py
@@ -13,6 +13,7 @@ from ...factories.logging_provider import (
     ErrorLog,
     RecommendationLog,
     LoggingProvider,
+    FeedbackLog,
 )
 from ...utilities.snapshots.snapshot_writer import SnapshotWriter
 
@@ -121,6 +122,17 @@ class RecommendationAgent(AgentBase):
         return recs
 
     def _run_agent_logic(self, *args, **kwargs) -> None:
+        feedback = kwargs.get("feedback")
+        if feedback:
+            for item in feedback:
+                self.log_feedback(
+                    FeedbackLog(
+                        experiment_id="exp",
+                        round=0,
+                        source="recommendation",
+                        feedback=str(item),
+                    )
+                )
         conv_logs: List[ConversationLog] = kwargs.get("conversation_log", [])
         qual_logs: List[CodeQualityLog] = kwargs.get("code_quality_log", [])
         scoring_logs: List[ScoringLog] = kwargs.get("scoring_log", [])

--- a/app/extensions/scoring_models/__init__.py
+++ b/app/extensions/scoring_models/__init__.py
@@ -1,14 +1,17 @@
 from .dummy_scoring_provider import DummyScoringProvider
 from .basic_scoring_provider import BasicScoringProvider
 from .advanced_scoring_provider import AdvancedScoringProvider
+from .adaptive_scoring_provider import AdaptiveScoringProvider
 from ...registries.scoring_models import SCORING_MODEL_REGISTRY
 
 SCORING_MODEL_REGISTRY.register("dummy", DummyScoringProvider)
 SCORING_MODEL_REGISTRY.register("basic", BasicScoringProvider)
 SCORING_MODEL_REGISTRY.register("advanced", AdvancedScoringProvider)
+SCORING_MODEL_REGISTRY.register("adaptive", AdaptiveScoringProvider)
 
 __all__ = [
     "DummyScoringProvider",
     "BasicScoringProvider",
     "AdvancedScoringProvider",
+    "AdaptiveScoringProvider",
 ]

--- a/app/extensions/scoring_models/adaptive_scoring_provider.py
+++ b/app/extensions/scoring_models/adaptive_scoring_provider.py
@@ -1,0 +1,38 @@
+from __future__ import annotations
+
+from typing import Any, Dict, List
+
+from .advanced_scoring_provider import AdvancedScoringProvider
+from ...utilities.feedback import FeedbackRepository
+from ...factories.logging_provider import LoggingProvider
+
+
+class AdaptiveScoringProvider(AdvancedScoringProvider):
+    """Scoring provider that adjusts weights based on feedback."""
+
+    def __init__(self, logger: LoggingProvider | None = None) -> None:
+        super().__init__(logger)
+        self.weights: Dict[str, float] = {
+            "maintainability_index": 1.0,
+            "cyclomatic_complexity": 1.0,
+            "recommendation_quality": 1.0,
+        }
+
+    def _score(
+        self, logs: Dict[str, List[Any]], experiment_id: str = "exp"
+    ) -> Dict[str, float]:
+        metrics = super()._score(logs, experiment_id)
+
+        for fb in FeedbackRepository.get_feedback(experiment_id):
+            text = fb.feedback.lower()
+            if "maintainability" in text:
+                self.weights["maintainability_index"] += 0.1
+            if "complexity" in text:
+                self.weights["cyclomatic_complexity"] += 0.1
+            if "recommendation" in text:
+                self.weights["recommendation_quality"] += 0.1
+
+        weighted = {
+            key: value * self.weights.get(key, 1.0) for key, value in metrics.items()
+        }
+        return weighted

--- a/app/factories/logging_provider.py
+++ b/app/factories/logging_provider.py
@@ -20,7 +20,9 @@ from ..utilities.metadata.logging.log_schemas import (
     ConversationLog,
     ExperimentLog,
     RecommendationLog,
+    FeedbackLog,
 )
+from ..utilities.feedback import FeedbackRepository
 
 
 LOG_MODEL_MAP = {
@@ -33,6 +35,7 @@ LOG_MODEL_MAP = {
     LogType.CONVERSATION: ConversationLog,
     LogType.EXPERIMENT: ExperimentLog,
     LogType.RECOMMENDATION: RecommendationLog,
+    LogType.FEEDBACK: FeedbackLog,
 }
 
 
@@ -145,6 +148,10 @@ class LoggingProvider:
     def log_recommendation(self, log: RecommendationLog) -> None:
         self.write(LogType.RECOMMENDATION, log)
 
+    def log_feedback(self, log: FeedbackLog) -> None:
+        self.write(LogType.FEEDBACK, log)
+        FeedbackRepository.add_feedback(log)
+
     def close(self) -> None:
         self.conn.close()
 
@@ -182,3 +189,6 @@ class LoggingMixin:
 
     def log_recommendation(self, log: RecommendationLog) -> None:
         self.logger.log_recommendation(log)
+
+    def log_feedback(self, log: FeedbackLog) -> None:
+        self.logger.log_feedback(log)

--- a/app/utilities/db.py
+++ b/app/utilities/db.py
@@ -149,5 +149,15 @@ def init_db(conn: sqlite3.Connection | None = None) -> sqlite3.Connection:
         )"""
     )
 
+    cur.execute(
+        """CREATE TABLE IF NOT EXISTS feedback_log (
+            experiment_id TEXT,
+            round INTEGER,
+            source TEXT,
+            feedback TEXT,
+            timestamp TEXT
+        )"""
+    )
+
     conn.commit()
     return conn

--- a/app/utilities/feedback.py
+++ b/app/utilities/feedback.py
@@ -1,0 +1,23 @@
+from __future__ import annotations
+
+from typing import ClassVar, Dict, List
+
+from .metadata.logging.log_schemas import FeedbackLog
+
+
+class FeedbackRepository:
+    """In-memory store for feedback logs."""
+
+    _data: ClassVar[Dict[str, List[FeedbackLog]]] = {}
+
+    @classmethod
+    def add_feedback(cls, log: FeedbackLog) -> None:
+        cls._data.setdefault(log.experiment_id, []).append(log)
+
+    @classmethod
+    def get_feedback(cls, experiment_id: str) -> List[FeedbackLog]:
+        return list(cls._data.get(experiment_id, []))
+
+    @classmethod
+    def clear(cls) -> None:
+        cls._data.clear()

--- a/app/utilities/metadata/logging/log_schemas.py
+++ b/app/utilities/metadata/logging/log_schemas.py
@@ -120,3 +120,14 @@ class RecommendationLog:
     recommendation: str
     context: str
     timestamp: datetime = field(default_factory=lambda: datetime.now(timezone.utc))
+
+
+@dataclass
+class FeedbackLog:
+    """Capture feedback for adaptive learning."""
+
+    experiment_id: str
+    round: int
+    source: str
+    feedback: str
+    timestamp: datetime = field(default_factory=lambda: datetime.now(timezone.utc))

--- a/feedback_loop_demo.ipynb
+++ b/feedback_loop_demo.ipynb
@@ -1,0 +1,44 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Feedback Loop Demo"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from importlib import import_module\n",
+    "from app.factories.agent import AgentFactory\n",
+    "from app.utilities.feedback import FeedbackRepository\n",
+    "from app.utilities.metadata.logging.log_schemas import FeedbackLog\n",
+    "\n",
+    "import_module(\"app.extensions.agents\")\n",
+    "import_module(\"app.extensions.tool_providers\")\n",
+    "\n",
+    "agent = AgentFactory.create(\"generator\", target=\"sample_module.py\")\n",
+    "agent.run(feedback=[\"initial pass\"])\n",
+    "FeedbackRepository.add_feedback(FeedbackLog('exp', 0, 'user', 'increase maintainability'))\n",
+    "agent.run(feedback=[f.feedback for f in FeedbackRepository.get_feedback('exp')])"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": ".venv",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python",
+   "version": "3.12.6"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/tests/test_feedback.py
+++ b/tests/test_feedback.py
@@ -1,0 +1,45 @@
+import unittest
+from importlib import import_module
+from unittest.mock import patch, MagicMock
+from pathlib import Path
+
+from app.utilities.feedback import FeedbackRepository
+from app.utilities.metadata.logging.log_schemas import FeedbackLog
+from app.factories.agent import AgentFactory
+
+
+class FeedbackTests(unittest.TestCase):
+    def setUp(self):
+        import_module("app.extensions.agents")
+        import_module("app.extensions.tool_providers")
+        FeedbackRepository.clear()
+
+    def test_repository(self):
+        log = FeedbackLog(
+            experiment_id="exp", round=0, source="tester", feedback="good"
+        )
+        FeedbackRepository.add_feedback(log)
+        logs = FeedbackRepository.get_feedback("exp")
+        self.assertEqual(len(logs), 1)
+        self.assertEqual(logs[0].feedback, "good")
+
+    @patch("app.extensions.agents.generator_agent.ToolProviderFactory.create")
+    @patch("app.extensions.agents.generator_agent.SnapshotWriter.write_snapshot")
+    @patch("app.extensions.agents.generator_agent.LoggingProvider.log_feedback")
+    def test_agent_accepts_feedback(self, log_fb, snap, mock_create):
+        stub = MagicMock()
+        stub.run.return_value = MagicMock()
+        mock_create.return_value = stub
+
+        tmp = Path("g.py")
+        tmp.write_text("x=1\n")
+        try:
+            agent = AgentFactory.create("generator", target=str(tmp))
+            agent.run(feedback=["formatting"])
+            log_fb.assert_called()
+        finally:
+            tmp.unlink(missing_ok=True)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- introduce `FeedbackLog` and `FeedbackRepository`
- update logging provider to handle feedback entries
- allow agents to log received feedback
- add adaptive scoring provider that adjusts weights using feedback
- create demo notebook and unit tests for feedback flow

## Testing
- `ruff check .`
- `radon cc -s app` *(fails: command not found)*
- `python app/utilities/tools/sonarcloud_runner.py`
- `python pytest tests` *(fails: ModuleNotFoundError: pandas)*