### PR TITLE
[Phase 19] add symbol graph cache demo

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ It supports:
 - Self-healing loops with test generation and validation (TestGenAgent)
 - Structured experiment logging for research and reproducibility
 - Human-in-the-loop feedback with SME scoring
+- Cached symbol graphs for faster repeated analysis
 
 ### Goals
 

--- a/symbol_graph_cache_demo.ipynb
+++ b/symbol_graph_cache_demo.ipynb
@@ -1,0 +1,63 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Symbol Graph Caching Demo"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Demonstrate how the `SymbolGraphProvider` reuses cached graphs for faster repeated analysis."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "execution_count": null,
+   "source": [
+    "from time import perf_counter\n",
+    "from app.extensions.context_providers.symbol_graph_provider import SymbolGraphProvider"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "execution_count": null,
+   "source": [
+    "provider = SymbolGraphProvider('sample_module.py')\n",
+    "start = perf_counter()\n",
+    "ctx = provider.get_context()\n",
+    "print(f'First build: {perf_counter() - start:.4f}s')\n",
+    "len(ctx['symbol_graph'])"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "execution_count": null,
+   "source": [
+    "start = perf_counter()\n",
+    "ctx = provider.get_context()\n",
+    "print(f'Second build (cached): {perf_counter() - start:.4f}s')\n",
+    "len(ctx['symbol_graph'])"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python",
+   "pygments_lexer": "ipython3"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}


### PR DESCRIPTION
## Summary
- add demonstration notebook for symbol graph caching

## Testing
- `black . --quiet`
- `ruff check .`
- `mypy .`
- `radon cc . -s` *(fails: command not found)*
- `pytest -q` *(fails: command not found)*