### PR TITLE
[Phase] integrate structured logging into state manager

### DIFF
--- a/app/extensions/state_managers/state_manager.py
+++ b/app/extensions/state_managers/state_manager.py
@@ -1,7 +1,12 @@
 from __future__ import annotations
 
+from datetime import datetime, timezone
+from typing import List
+
 from ...abstract_classes.state_manager_base import StateManagerBase
+from ...enums.system_enums import SystemState, StateTransitionReason
 from ...factories.logging_provider import LoggingProvider
+from ...utilities.metadata.logging.log_schemas import StateLog, StateTransitionLog
 
 
 class StateManager(StateManagerBase):
@@ -9,7 +14,57 @@ class StateManager(StateManagerBase):
 
     def __init__(self, logger: LoggingProvider | None = None) -> None:
         super().__init__(logger)
+        self.current_state = SystemState.START
+        self.state_logs: List[StateLog] = []
+        self.transition_logs: List[StateTransitionLog] = []
 
     def _run_state_logic(self, *args, **kwargs) -> None:
         state = kwargs.get("state")
         self._log.info("Running state logic for %s", state)
+
+    def transition_state(
+        self,
+        experiment_id: str,
+        round: int,
+        from_state: SystemState,
+        to_state: SystemState,
+        reason: StateTransitionReason,
+    ) -> None:
+        """Log a state transition and update current state."""
+        log = StateTransitionLog(
+            experiment_id=experiment_id,
+            round=round,
+            from_state=from_state,
+            to_state=to_state,
+            reason=reason,
+            timestamp=datetime.now(timezone.utc),
+        )
+        self.transition_logs.append(log)
+        self.log_transition(log)
+        self._log.info("%s -> %s", from_state.value, to_state.value)
+        self.current_state = to_state
+
+    def run_state(
+        self,
+        experiment_id: str,
+        system: str,
+        round: int,
+        state: SystemState,
+        action: str,
+        score: float | None = None,
+        details: str | None = "",
+    ) -> None:
+        """Execute state logic and log the action."""
+        self._run_state_logic(state=state)
+        log = StateLog(
+            experiment_id=experiment_id,
+            system=system,
+            round=round,
+            state=state,
+            action=action,
+            score=score,
+            details=details,
+            timestamp=datetime.now(timezone.utc),
+        )
+        self.state_logs.append(log)
+        self.log_state(log)

--- a/tests/test_state_manager_logging.py
+++ b/tests/test_state_manager_logging.py
@@ -1,0 +1,55 @@
+import sqlite3
+from importlib import import_module
+
+from app.extensions.state_managers.state_manager import StateManager
+from app.enums.system_enums import SystemState, StateTransitionReason
+from app.factories.logging_provider import LoggingProvider
+
+
+def test_state_manager_logging():
+    import_module("app.extensions.state_managers")
+    conn = sqlite3.connect(":memory:")
+    logger = LoggingProvider(connection=conn)
+    manager = StateManager(logger=logger)
+
+    manager.transition_state(
+        experiment_id="exp",
+        round=1,
+        from_state=SystemState.START,
+        to_state=SystemState.GENERATE,
+        reason=StateTransitionReason.FIRST_ROUND,
+    )
+    manager.run_state(
+        experiment_id="exp",
+        system="system",
+        round=1,
+        state=SystemState.GENERATE,
+        action="run",
+        score=1.0,
+        details="",
+    )
+
+    cur = conn.cursor()
+    trans = cur.execute(
+        "SELECT experiment_id, round, from_state, to_state, reason FROM state_transition_log"
+    ).fetchone()
+    assert trans == (
+        "exp",
+        1,
+        SystemState.START.value,
+        SystemState.GENERATE.value,
+        StateTransitionReason.FIRST_ROUND.value,
+    )
+
+    state = cur.execute(
+        "SELECT experiment_id, system, round, state, action, score, details FROM state_log"
+    ).fetchone()
+    assert state == (
+        "exp",
+        "system",
+        1,
+        SystemState.GENERATE.value,
+        "run",
+        1.0,
+        "",
+    )


### PR DESCRIPTION
## Summary
- extend `StateManager` with `run_state` and `transition_state` methods
- store and log `StateLog` and `StateTransitionLog` entries
- update `SystemManager` to use new state manager logging
- add unit test validating state and transition logs

## Testing
- `black . --quiet`
- `mypy . --install-types --non-interactive`
- `python -m radon cc . -s` *(fails: No module named radon)*
- `ruff check .`
- `python -m pytest -q` *(fails: No module named pytest)*